### PR TITLE
add index page, some nav structure

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,104 @@
+div.col-md-9 h1:first-of-type {
+    text-align: center;
+    font-size: 60px;
+    font-weight: 300;
+}
+
+div.col-md-9 h2:first-of-type {
+    text-align: center;
+    font-size: 30px;
+    font-weight: 300;
+}
+
+div.col-md-9>p:first-of-type {
+    text-align: center;
+}
+
+div.col-md-9 p.admonition-title:first-of-type {
+    text-align: left;
+}
+
+div.col-md-9 h1:first-of-type .headerlink {
+    display: none;
+}
+
+div.admonition.block>.admonition-title {
+    display: none;
+}
+
+.admonition.new, details.new {
+    color: #15654a;
+    background-color: #edfff9;
+    border-color: #bcf1e8;
+}
+.admonition.example, details.example {
+    color: #353579;
+    background-color: #f0f1ff;
+    border-color: #d8dcf0;
+}
+
+/* Definition List styles */
+
+dd {
+    padding-left: 20px;
+}
+
+.card-body svg {
+    width: 100%;
+    padding: 0 50px;
+    height: auto;
+}
+
+/* Homepage */
+
+body.homepage div.jumbotron {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    padding-bottom: 0;
+}
+
+body.homepage div.jumbotron div.card {
+    margin-bottom: 2rem;
+}
+
+body.homepage>div.container>div.row>div.col-md-3 {
+    display: none;
+}
+
+body.homepage>div.container>div.row>div.col-md-9 {
+    margin-left: 0;
+    flex: 0 0 100%;
+    max-width: 100%;
+}
+
+/* mkdocstrings */
+
+.doc-object {
+    padding-left: 10px;
+    border-left: 4px solid rgba(230, 230, 230);
+}
+
+.doc-contents .field-body p:first-of-type {
+    display: inline;
+}
+
+.doc-label-class-attribute {
+    display: none;
+}
+
+h2.doc-heading {
+    font-size: 1.5rem;
+}
+h3.doc-heading {
+    font-size: 1.4rem;
+}
+h4.doc-heading {
+    font-size: 1.3rem;
+}
+h5.doc-heading {
+    font-size: 1.2rem;
+}
+
+.doc-contents {
+    padding-left: 0;
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,3 @@
+# Getting started
+
+_TODO: Install opam, editor config, templates_

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,77 @@
-# Welcome to MkDocs
+# Melange
 
-For full documentation visit [mkdocs.org](https://www.mkdocs.org).
+## OCaml for JavaScript developers
 
-## Commands
+---
 
-* `mkdocs new [dir-name]` - Create a new project.
-* `mkdocs serve` - Start the live-reloading docs server.
-* `mkdocs build` - Build the documentation site.
-* `mkdocs -h` - Print help message and exit.
+Melange is a fork of the OCaml compiler that strives to provide the best
+integration with both the Ocaml and JavaScript ecosystems.
+To know more about it start by reading the [introductory tutorial](getting-started.md),
+then check the [Learn](learn.md) section for more information.
 
-## Project layout
+<div class="text-center">
+<a href="getting-started" class="btn btn-primary" role="button">Getting Started</a>
+<a href="learn" class="btn btn-primary" role="button">Learn</a>
+</div>
 
-    mkdocs.yml    # The configuration file.
-    docs/
-        index.md  # The documentation homepage.
-        ...       # Other markdown pages, images and other files.
+<div class="jumbotron">
+<h2 class="display-4 text-center">Features</h2>
+
+<div class="row">
+  <div class="col-sm-6">
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">A Solid Type System</h3>
+        <p class="card-text">
+            Melange leverages OCaml's powerful type system to catch more bugs at
+            compile time. Large, complex codebases become easy to maintain and
+            refactor.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6">
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">First-Class Editor and Tooling</h3>
+        <p class="card-text">
+            Melange can use the same editor integrations as OCaml, which exist
+            for VSCode, Vim, or Emacs. They allow to provide type inspection,
+            autocomplete and more. It also has first-class integration with <a
+            href="https://dune.build/">Dune</a>, OCaml's most used build system.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-6">
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">JavaScript Integration</h3>
+        <p class="card-text">
+            Whether you want to use existing JavaScript packages from NPM, or
+            use your own JavaScript libraries in your projects, Melange has you
+            covered. With an expressive bindings language, and an ergonomic
+            compilation model, Melange can help you build robust applications
+            that leverage functionality from the JavaScript ecosystem.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-6">
+    <div class="card">
+      <div class="card-body">
+        <h3 class="card-title">Stable and Industry Backed</h3>
+        <p class="card-text">
+            Melange builds on top of decades of type system research, compiler
+            engineering and tooling development to provide a polished
+            developer experience. Companies like Ahrefs use Melange daily to
+            deploy web applications to their users.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,11 @@
 
 ---
 
-Melange is a fork of the OCaml compiler that strives to provide the best
-integration with both the Ocaml and JavaScript ecosystems.
-To know more about it start by reading the [introductory tutorial](getting-started.md),
-then check the [Learn](learn.md) section for more information.
+Melange is a fork of the OCaml compiler that compiles to JavaScript. Melange
+strives to provide the best integration with both the OCaml and JavaScript
+ecosystems. To know more about it start by reading the [introductory
+tutorial](getting-started.md), then check the [Learn](learn.md) section for more
+information.
 
 <div class="text-center">
 <a href="getting-started" class="btn btn-primary" role="button">Getting Started</a>

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -1,0 +1,3 @@
+# Learn
+
+_TODO: This will be a one-page with "all the things" in it_

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,1 +1,16 @@
-site_name: My Docs
+site_name: Melange
+
+theme:
+  name: mkdocs
+  locale: en
+  highlightjs: true
+  hljs_languages:
+    - ocaml
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Learn: learn.md
+
+extra_css:
+  - css/extra.css


### PR DESCRIPTION
Some initial structure:
- Landing page, with some features listed
- Top level navigation (Home, Getting Started, Learn)

Can be loaded locally with `mkdocs serve`. Otherwise, I made a deployment to https://melange-re.github.io/documentation-site/ (will set up GH action in a new PR).

Next, will continue with Getting Started in new PR.