### PR TITLE
comm with js: code generation / `bs.deriving`

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -110,3 +110,8 @@ blockquote {
     padding: 1em 10px .1em 10px;
     quotes: "\201C""\201D""\2018""\2019"
 }
+
+/* Needed for code spans like `{ abstract = light }` to render ok when they get broken into 2 lines in md */
+.rst-content code {
+    white-space:nowrap;
+}


### PR DESCRIPTION
Fixes #16 and #14.

I had a lot of trouble coming up with a structure that made sense for this section. In the end, I decided to arrange the information based on the types that can be used with `bs.deriving`. This made it easier to arrange the possibilities.